### PR TITLE
✨ Convert ASP.NET Identity Codes to Human Readable Strings

### DIFF
--- a/src/API/Core/Winterhaven.API.Core.Application/Requests/Users/LoginUser/LoginUserRequestValidator.cs
+++ b/src/API/Core/Winterhaven.API.Core.Application/Requests/Users/LoginUser/LoginUserRequestValidator.cs
@@ -14,10 +14,12 @@ public sealed class LoginUserRequestValidator : AbstractValidator<LoginUserReque
     {
         this.RuleFor(x => x.Username)
             .NotEmpty()
-            .WithMessage("Username must not be empty.");
+            .WithMessage("Username must not be empty.")
+            .OverridePropertyName("Username");
 
         this.RuleFor(x => x.Password)
             .NotEmpty()
-            .WithMessage("Password must not be empty.");
+            .WithMessage("Password must not be empty.")
+            .OverridePropertyName("Password");
     }
 }

--- a/src/API/Core/Winterhaven.API.Core.Application/Requests/Users/RefreshToken/RefreshTokenRequestValidator.cs
+++ b/src/API/Core/Winterhaven.API.Core.Application/Requests/Users/RefreshToken/RefreshTokenRequestValidator.cs
@@ -14,6 +14,7 @@ public sealed class RefreshTokenRequestValidator : AbstractValidator<RefreshToke
     {
         this.RuleFor(request => request.RefreshToken)
             .NotEmpty()
-            .WithMessage("Refresh token must not be empty.");
+            .WithMessage("Refresh token must not be empty.")
+            .OverridePropertyName("Refresh Token");
     }
 }

--- a/src/API/Core/Winterhaven.API.Core.Application/Requests/Users/RegisterUser/RegisterUserRequestValidator.cs
+++ b/src/API/Core/Winterhaven.API.Core.Application/Requests/Users/RegisterUser/RegisterUserRequestValidator.cs
@@ -18,16 +18,19 @@ public sealed class RegisterUserRequestValidator : AbstractValidator<RegisterUse
             .NotEmpty()
             .WithMessage("Email address must not be empty.")
             .EmailAddress(EmailValidationMode.AspNetCoreCompatible)
-            .WithMessage("Email address must be a valid format.");
+            .WithMessage("Email address must be a valid format.")
+            .OverridePropertyName("Email Address");
 
         this.RuleFor(x => x.Username)
             .NotNull()
             .WithMessage("Username must not be null.")
-            .SetValidator(new UsernameValidator());
+            .SetValidator(new UsernameValidator())
+            .OverridePropertyName("Username");
 
         this.RuleFor(x => x.Password)
             .NotNull()
             .WithMessage("Password must not be null.")
-            .SetValidator(new PasswordValidator());
+            .SetValidator(new PasswordValidator())
+            .OverridePropertyName("Password");
     }
 }

--- a/src/API/Core/Winterhaven.API.Core.Application/Validators/Users/UsernameValidator.cs
+++ b/src/API/Core/Winterhaven.API.Core.Application/Validators/Users/UsernameValidator.cs
@@ -7,10 +7,10 @@ internal sealed class UsernameValidator : AbstractValidator<string>
 {
     internal UsernameValidator()
     {
-        this.RuleFor(x => x).NotEmpty().WithMessage("Name cannot be empty.");
-        this.RuleFor(x => x).MinimumLength(3).WithMessage("Name must be at least 3 characters.");
-        this.RuleFor(x => x).MaximumLength(12).WithMessage("Name must be no more than 12 characters.");
-        this.RuleFor(x => x).Must(ContainsLegalCharacters).WithMessage("Name can only contain alphanumerical characters (and '-' or '_')");
+        this.RuleFor(x => x).NotEmpty().WithMessage("Username cannot be empty.");
+        this.RuleFor(x => x).MinimumLength(3).WithMessage("Username must be at least 3 characters.");
+        this.RuleFor(x => x).MaximumLength(12).WithMessage("Username must be no more than 12 characters.");
+        this.RuleFor(x => x).Must(ContainsLegalCharacters).WithMessage("Username can only contain alphanumerical characters (and '-' or '_')");
     }
 
     private static bool ContainsLegalCharacters(string username)

--- a/src/API/Infrastructure/Winterhaven.API.Infrastructure/Extensions/ServiceCollectionExtensions.cs
+++ b/src/API/Infrastructure/Winterhaven.API.Infrastructure/Extensions/ServiceCollectionExtensions.cs
@@ -68,7 +68,8 @@ public static class ServiceCollectionExtensions
             .AddRoles<IdentityRole<Guid>>()
             .AddEntityFrameworkStores<DatabaseContext>()
             .AddSignInManager<SignInManager<IdentityUser<Guid>>>()
-            .AddDefaultTokenProviders();
+            .AddDefaultTokenProviders()
+            .AddErrorDescriber<UserAccountIdentityErrorDescriber>();
 
         services.Configure<IdentityOptions>(x =>
         {

--- a/src/API/Infrastructure/Winterhaven.API.Infrastructure/Services/Maps/MapLocator.cs
+++ b/src/API/Infrastructure/Winterhaven.API.Infrastructure/Services/Maps/MapLocator.cs
@@ -48,7 +48,7 @@ internal sealed class MapLocator : IMapLocator
         string data = await this.fileSystem.File.ReadAllTextAsync(fullPath, cancellationToken).ConfigureAwait(false);
 
         // If there is no content in the TMX file, that is not a valid TMX file - so throw an error (500).
-        if (data.Length == 0)
+        if (string.IsNullOrWhiteSpace(data))
         {
             this.logger.LogWarning("Failed to read contents of map at path: '{FullPath}'", fullPath);
             throw new InvalidOperationException($"Failed to read contents of map at path: '{fullPath}'");

--- a/src/API/Infrastructure/Winterhaven.API.Infrastructure/Services/Users/UserAccountIdentityErrorDescriber.cs
+++ b/src/API/Infrastructure/Winterhaven.API.Infrastructure/Services/Users/UserAccountIdentityErrorDescriber.cs
@@ -1,0 +1,114 @@
+﻿namespace Winterhaven.API.Infrastructure.Services.Users;
+
+using Microsoft.AspNetCore.Identity;
+
+internal sealed class UserAccountIdentityErrorDescriber : IdentityErrorDescriber
+{
+    public override IdentityError DefaultError()
+    {
+        return new()
+        {
+            Code = "Error",
+            Description = "Something went wrong on our end. Please try again in a moment."
+        };
+    }
+
+    public override IdentityError DuplicateEmail(string email)
+    {
+        return new()
+        {
+            Code = "Email Address",
+            Description = $"'{email}' is already registered to an account."
+        };
+    }
+
+    public override IdentityError DuplicateUserName(string userName)
+    {
+        return new()
+        {
+            Code = "Username",
+            Description = $"'{userName}' is already taken. Please choose another."
+        };
+    }
+
+    public override IdentityError InvalidEmail(string? email)
+    {
+        return new()
+        {
+            Code = "Email Address",
+            Description = $"'{email}' is not a valid email address."
+        };
+    }
+
+    public override IdentityError InvalidUserName(string? userName)
+    {
+        return new()
+        {
+            Code = "Username",
+            Description = $"'{userName}' is not a valid username.",
+        };
+    }
+
+    public override IdentityError PasswordMismatch()
+    {
+        return new()
+        {
+            Code = "Password",
+            Description = "The password you entered is incorrect."
+        };
+    }
+
+    public override IdentityError PasswordRequiresDigit()
+    {
+        return new()
+        {
+            Code = "Password",
+            Description = "Your password must contain at least one number (0–9)."
+        };
+    }
+
+    public override IdentityError PasswordRequiresLower()
+    {
+        return new()
+        {
+            Code = "Password",
+            Description = "Your password must contain at least one lowercase letter (a–z)."
+        };
+    }
+
+    public override IdentityError PasswordRequiresNonAlphanumeric()
+    {
+        return new()
+        {
+            Code = "Password",
+            Description = "Your password must contain at least one special character (e.g. !, @, #, $)."
+        };
+    }
+
+    public override IdentityError PasswordRequiresUniqueChars(int uniqueChars)
+    {
+        return new()
+        {
+            Code = "Password",
+            Description = $"Your password must contain at least {uniqueChars} unique character{(uniqueChars == 1 ? "" : "s")}."
+        };
+    }
+
+    public override IdentityError PasswordRequiresUpper()
+    {
+        return new()
+        {
+            Code = "Password",
+            Description = "Your password must contain at least one uppercase letter (A–Z)."
+        };
+    }
+
+    public override IdentityError PasswordTooShort(int length)
+    {
+        return new()
+        {
+            Code = "Password",
+            Description = $"Your password must be at least {length} characters long."
+        };
+    }
+}

--- a/src/API/Tests/Winterhaven.API.Tests/Core/Application/Requests/Maps/GetMap/GetMapRequestHandlerTests.cs
+++ b/src/API/Tests/Winterhaven.API.Tests/Core/Application/Requests/Maps/GetMap/GetMapRequestHandlerTests.cs
@@ -92,7 +92,7 @@ internal sealed class GetMapRequestHandlerTests
 
         this.mapData = new MapData(
             Name: "world-map",
-            Data: new byte[] { 1, 2, 3 });
+            Data: "data");
 
         this.mapLocator
             .LocateMapDataAsync(this.mapData.Name, Arg.Any<CancellationToken>())

--- a/src/API/Tests/Winterhaven.API.Tests/Core/Application/Requests/Users/RefreshToken/RefreshTokenRequestValidatorTests.cs
+++ b/src/API/Tests/Winterhaven.API.Tests/Core/Application/Requests/Users/RefreshToken/RefreshTokenRequestValidatorTests.cs
@@ -28,7 +28,7 @@ internal sealed class RefreshTokenRequestValidatorTests
         var result = this.validator.TestValidate(request);
 
         // Assert
-        result.ShouldHaveValidationErrorFor(x => x.RefreshToken);
+        result.ShouldHaveValidationErrorFor("Refresh Token");
     }
 
     [Test]
@@ -42,6 +42,6 @@ internal sealed class RefreshTokenRequestValidatorTests
         var result = this.validator.TestValidate(request);
 
         // Assert
-        result.ShouldNotHaveValidationErrorFor(x => x.RefreshToken);
+        result.ShouldNotHaveValidationErrorFor("Refresh Token");
     }
 }

--- a/src/API/Tests/Winterhaven.API.Tests/Core/Application/Requests/Users/RegisterUser/RegisterUserRequestValidatorTests.cs
+++ b/src/API/Tests/Winterhaven.API.Tests/Core/Application/Requests/Users/RegisterUser/RegisterUserRequestValidatorTests.cs
@@ -34,7 +34,7 @@ internal sealed class RegisterUserRequestValidatorTests
         var result = this.validator.TestValidate(request);
 
         // Assert
-        result.ShouldHaveValidationErrorFor(nameof(request.EmailAddress));
+        result.ShouldHaveValidationErrorFor("Email Address");
     }
 
     [Test]
@@ -50,7 +50,7 @@ internal sealed class RegisterUserRequestValidatorTests
         var result = this.validator.TestValidate(request);
 
         // Assert
-        result.ShouldNotHaveValidationErrorFor(nameof(request.EmailAddress));
+        result.ShouldNotHaveValidationErrorFor("Email Address");
     }
 
     [Test]

--- a/src/API/Tests/Winterhaven.API.Tests/Infrastructure/Services/Maps/MapLocatorTests.cs
+++ b/src/API/Tests/Winterhaven.API.Tests/Infrastructure/Services/Maps/MapLocatorTests.cs
@@ -7,6 +7,7 @@ using NUnit.Framework;
 using System;
 using System.IO;
 using System.IO.Abstractions;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Winterhaven.API.Core.Domain.Exceptions;

--- a/src/API/Tests/Winterhaven.API.Tests/Infrastructure/Services/Maps/MapLocatorTests.cs
+++ b/src/API/Tests/Winterhaven.API.Tests/Infrastructure/Services/Maps/MapLocatorTests.cs
@@ -7,7 +7,6 @@ using NUnit.Framework;
 using System;
 using System.IO;
 using System.IO.Abstractions;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Winterhaven.API.Core.Domain.Exceptions;
@@ -51,11 +50,11 @@ internal sealed class MapLocatorTests
     {
         // Arrange
         const string name = "testmap";
-        byte[] expectedBytes = new byte[] { 1, 2, 3 };
+        string expectedData = "data";
         string fullPath = System.IO.Path.Combine(this.options.Value.BasePath, $"{name}.tmx");
 
         this.fileSystem.File.Exists(fullPath).Returns(true);
-        this.fileSystem.File.ReadAllBytesAsync(fullPath, Arg.Any<CancellationToken>()).Returns(expectedBytes);
+        this.fileSystem.File.ReadAllTextAsync(fullPath, Arg.Any<CancellationToken>()).Returns(expectedData);
 
         // Act
         await this.locator.LocateMapDataAsync(name, default).ConfigureAwait(false);
@@ -72,7 +71,7 @@ internal sealed class MapLocatorTests
         string expectedPath = Path.Combine(this.options.Value.BasePath, $"{name}.tmx");
 
         this.fileSystem.File.Exists(expectedPath).Returns(true);
-        this.fileSystem.File.ReadAllBytesAsync(expectedPath, Arg.Any<CancellationToken>()).Returns(Array.Empty<byte>());
+        this.fileSystem.File.ReadAllTextAsync(expectedPath, Arg.Any<CancellationToken>()).Returns("data");
 
         // Act
         try
@@ -98,7 +97,7 @@ internal sealed class MapLocatorTests
 #pragma warning restore CA1308 // Normalize strings to uppercase
 
         this.fileSystem.File.Exists(expectedPath).Returns(true);
-        this.fileSystem.File.ReadAllBytesAsync(expectedPath, Arg.Any<CancellationToken>()).Returns(new byte[] { 1, 2, 3 });
+        this.fileSystem.File.ReadAllTextAsync(expectedPath, Arg.Any<CancellationToken>()).Returns("data");
 
         // Act
         await this.locator.LocateMapDataAsync(name, default).ConfigureAwait(false);
@@ -108,25 +107,24 @@ internal sealed class MapLocatorTests
     }
 
     [Test]
-    public async Task LocateMapDataAsyncShouldInvokeReadAllBytesAsyncOnceWhenFileExistsAndHasContent()
+    public async Task LocateMapDataAsyncShouldInvokeReadAllTextAsyncOnceWhenFileExistsAndHasContent()
     {
         // Arrange
         const string name = "testmap";
-        byte[] expectedBytes = new byte[] { 1, 2, 3 };
         string fullPath = System.IO.Path.Combine(this.options.Value.BasePath, $"{name}.tmx");
 
         this.fileSystem.File.Exists(fullPath).Returns(true);
-        this.fileSystem.File.ReadAllBytesAsync(fullPath, Arg.Any<CancellationToken>()).Returns(expectedBytes);
+        this.fileSystem.File.ReadAllTextAsync(fullPath, Arg.Any<CancellationToken>()).Returns("data");
 
         // Act
         await this.locator.LocateMapDataAsync(name, default).ConfigureAwait(false);
 
         // Assert
-        await this.fileSystem.File.Received(1).ReadAllBytesAsync(fullPath, Arg.Any<CancellationToken>()).ConfigureAwait(false);
+        await this.fileSystem.File.Received(1).ReadAllTextAsync(fullPath, Arg.Any<CancellationToken>()).ConfigureAwait(false);
     }
 
     [Test]
-    public async Task LocateMapDataAsyncShouldInvokeReadAllBytesAsyncWithCorrectFullPath()
+    public async Task LocateMapDataAsyncShouldInvokeReadAllTextAsyncWithCorrectFullPath()
     {
         // Arrange
         const string name = "testmap";
@@ -137,17 +135,17 @@ internal sealed class MapLocatorTests
 #pragma warning restore CA1308 // Normalize strings to uppercase
 
         this.fileSystem.File.Exists(expectedPath).Returns(true);
-        this.fileSystem.File.ReadAllBytesAsync(expectedPath, Arg.Any<CancellationToken>()).Returns([1, 2, 3]);
+        this.fileSystem.File.ReadAllTextAsync(expectedPath, Arg.Any<CancellationToken>()).Returns("data");
 
         // Act
         await this.locator.LocateMapDataAsync(name, default).ConfigureAwait(false);
 
         // Assert
-        await this.fileSystem.File.Received(1).ReadAllBytesAsync(expectedPath, Arg.Any<CancellationToken>()).ConfigureAwait(false);
+        await this.fileSystem.File.Received(1).ReadAllTextAsync(expectedPath, Arg.Any<CancellationToken>()).ConfigureAwait(false);
     }
 
     [Test]
-    public async Task LocateMapDataAsyncShouldNotInvokeReadAllBytesAsyncWhenFileDoesNotExist()
+    public async Task LocateMapDataAsyncShouldNotInvokeReadAllTextAsyncWhenFileDoesNotExist()
     {
         // Arrange
         this.fileSystem.File.Exists(Arg.Any<string>()).Returns(false);
@@ -162,7 +160,7 @@ internal sealed class MapLocatorTests
         }
 
         // Assert
-        await this.fileSystem.File.DidNotReceive().ReadAllBytesAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).ConfigureAwait(false);
+        await this.fileSystem.File.DidNotReceive().ReadAllTextAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).ConfigureAwait(false);
     }
 
     [Test]
@@ -170,17 +168,17 @@ internal sealed class MapLocatorTests
     {
         // Arrange
         const string name = "testmap";
-        byte[] expectedBytes = [1, 2, 3];
+        var expectedData = "data";
         string fullPath = System.IO.Path.Combine(this.options.Value.BasePath, $"{name}.tmx");
 
         this.fileSystem.File.Exists(fullPath).Returns(true);
-        this.fileSystem.File.ReadAllBytesAsync(fullPath, Arg.Any<CancellationToken>()).Returns(expectedBytes);
+        this.fileSystem.File.ReadAllTextAsync(fullPath, Arg.Any<CancellationToken>()).Returns(expectedData);
 
         // Act
         var result = await this.locator.LocateMapDataAsync(name, default).ConfigureAwait(false);
 
         // Assert
-        Assert.That(result.Data.ToArray(), Is.EqualTo(expectedBytes));
+        Assert.That(result.Data, Is.EqualTo(expectedData));
     }
 
     [Test]
@@ -188,11 +186,11 @@ internal sealed class MapLocatorTests
     {
         // Arrange
         const string name = "testmap";
-        byte[] expectedBytes = new byte[] { 1, 2, 3 };
+        var expectedData = "data";
         string fullPath = System.IO.Path.Combine(this.options.Value.BasePath, $"{name}.tmx");
 
         this.fileSystem.File.Exists(fullPath).Returns(true);
-        this.fileSystem.File.ReadAllBytesAsync(fullPath, Arg.Any<CancellationToken>()).Returns(expectedBytes);
+        this.fileSystem.File.ReadAllTextAsync(fullPath, Arg.Any<CancellationToken>()).Returns(expectedData);
 
         // Act
         var result = await this.locator.LocateMapDataAsync(name, default).ConfigureAwait(false);
@@ -230,7 +228,21 @@ internal sealed class MapLocatorTests
         string expectedPath = Path.Combine(this.options.Value.BasePath, $"{name}.tmx");
 
         this.fileSystem.File.Exists(expectedPath).Returns(true);
-        this.fileSystem.File.ReadAllBytesAsync(expectedPath, Arg.Any<CancellationToken>()).Returns(Array.Empty<byte>());
+        this.fileSystem.File.ReadAllTextAsync(expectedPath, Arg.Any<CancellationToken>()).Returns("");
+
+        // Act and assert
+        Assert.ThrowsAsync<InvalidOperationException>(() => this.locator.LocateMapDataAsync(name, default));
+    }
+
+    [Test]
+    public void LocateMapDataAsyncShouldThrowInvalidOperationExceptionWhenFileIsWhiteSpace()
+    {
+        // Arrange
+        const string name = "testmap";
+        string expectedPath = Path.Combine(this.options.Value.BasePath, $"{name}.tmx");
+
+        this.fileSystem.File.Exists(expectedPath).Returns(true);
+        this.fileSystem.File.ReadAllTextAsync(expectedPath, Arg.Any<CancellationToken>()).Returns(" \r\n\t");
 
         // Act and assert
         Assert.ThrowsAsync<InvalidOperationException>(() => this.locator.LocateMapDataAsync(name, default));


### PR DESCRIPTION
# Description

- Updated validators to override property names when validation fails before hitting the user account services.
- Created a `UserAccountIdentityErrorDescriptor` to handle returning human readable strings.

Fixes #60

## Type of change

- [x] New feature (non-breaking change which adds functionality).

## How Has This Been Tested?

This has been tested purely through scalar and the API. I've logged an issue to provide unit tests for `UserAccountIdentityErrorDescriber` as well as update the validator tests to ensure the property names have been overridden.

## Checklist:

- [x] I have updated the CHANGELOG to reflect my changes
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
