### PR TITLE
🧹 Consolidate Version Numbering Logic

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,9 @@ jobs:
 
       - name: Restore
         run: dotnet restore src/Server.slnx
+        env: # TODO: Remove this, hack fix for this issue: https://github.com/reactiveui/refit/issues/2114
+          # Stops NuGet from going online to check revocation status
+          NUGET_CERT_REVOCATION_MODE: offline
 
       - name: Build
         run: dotnet build src/Server.slnx --configuration Release --no-restore

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,18 +1,14 @@
 name: Release
-
 on:
   push:
     tags:
       - "v*"
-
 permissions:
   contents: write
   packages: write
-
 jobs:
   release:
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -22,7 +18,17 @@ jobs:
         with:
           dotnet-version: "9.0.x"
 
-      - name: Create GitHub Release
+      - name: Extract Version
+        id: version
+        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
+
+      - name: Build
+        run: dotnet build src/Server.slnx --configuration Release /p:Version=${{ steps.version.outputs.VERSION }}
+
+      - name: Test
+        run: dotnet test src/Server.slnx --configuration Release --no-build --verbosity normal
+
+      - name: Release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.ref_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,15 @@
 name: Release
+
 on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
+
 permissions:
   contents: write
   packages: write
+
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -33,6 +33,9 @@ jobs:
 
       - name: Build
         run: dotnet build src/Server.slnx --no-incremental
+        env: # TODO: Remove this, hack fix for this issue: https://github.com/reactiveui/refit/issues/2114
+          # Stops NuGet from going online to check revocation status
+          NUGET_CERT_REVOCATION_MODE: offline          
 
       - name: Test with Coverage
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#59] - Server Sends Error Messages to Client (_by [@mathew-odwyer]_).
 
+### Changed
+
+- [#174] - Consolidated Version Numbering Logic (_by [@mathew-odwyer]_).
+
 ## [v0.3.0] - 27-05-2026
 
 ### Added
@@ -75,6 +79,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [v0.2.0]: https://github.com/mathew-odwyer/Server/releases/tag/v0.2.0
 [v0.1.0]: https://github.com/mathew-odwyer/Server/releases/tag/v0.0.1
 
+[#174]: https://github.com/mathew-odwyer/Server/issues/174
 [#95]: https://github.com/mathew-odwyer/Server/issues/95
 [#59]: https://github.com/mathew-odwyer/Server/issues/59
 [#96]: https://github.com/mathew-odwyer/Server/issues/96

--- a/src/API/Dockerfile
+++ b/src/API/Dockerfile
@@ -3,6 +3,10 @@ FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine AS build
 
 WORKDIR /app
 
+# TODO: Remove this, hack fix for this issue: https://github.com/reactiveui/refit/issues/2114
+# Stops NuGet from going online to check revocation status
+ENV NUGET_CERT_REVOCATION_MODE=offline
+
 # Copy shared properties first
 COPY Directory.Build.props .
 COPY Directory.Packages.props .

--- a/src/API/Dockerfile
+++ b/src/API/Dockerfile
@@ -1,4 +1,4 @@
-# Build Stage
+﻿# Build Stage
 FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine AS build
 
 WORKDIR /app
@@ -22,6 +22,9 @@ COPY API/Winterhaven.API.Presentation/Winterhaven.API.Presentation.csproj \
 
 COPY API/Winterhaven.API.Tests/Winterhaven.API.Tests.csproj \
     API/Winterhaven.API.Tests/
+
+COPY Common/Winterhaven.Common/Winterhaven.Common.csproj \
+    Common/Winterhaven.Common/
 
 COPY Common/Winterhaven.Common.DTOs/Winterhaven.Common.DTOs.csproj \
     Common/Winterhaven.Common.DTOs/

--- a/src/API/Winterhaven.API.Presentation/Extensions/ServiceCollectionExtensions.cs
+++ b/src/API/Winterhaven.API.Presentation/Extensions/ServiceCollectionExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
-using System.Reflection;
 using System.Text;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
@@ -17,6 +16,7 @@ using Winterhaven.API.Presentation.Mappings.Players;
 using Winterhaven.API.Presentation.Mappings.Users;
 using Winterhaven.API.Presentation.Transformers;
 using Winterhaven.API.Presentation.Transformers.Security;
+using Winterhaven.Common;
 
 namespace Winterhaven.API.Presentation.Extensions;
 
@@ -104,12 +104,7 @@ internal static class ServiceCollectionExtensions
         services.AddHealthChecks();
         services.AddEndpointsApiExplorer();
 
-        string version = Assembly
-            .GetExecutingAssembly()
-            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
-            ?.InformationalVersion ?? "unknown";
-
-        services.AddOpenApi($"v{version}", x => x
+        services.AddOpenApi($"v{BuildInformation.Version}", x => x
                 .AddDocumentTransformer<WinterhavenTransformer>()
                 .AddDocumentTransformer<BearerSecuritySchemeTransformer>()
                 .AddDocumentTransformer<ApiKeySecuritySchemeTransformer>());

--- a/src/API/Winterhaven.API.Presentation/Winterhaven.API.Presentation.csproj
+++ b/src/API/Winterhaven.API.Presentation/Winterhaven.API.Presentation.csproj
@@ -15,6 +15,7 @@
 	</ItemGroup>
 	<ItemGroup>
 	  <ProjectReference Include="..\..\Common\Winterhaven.Common.DTOs\Winterhaven.Common.DTOs.csproj" />
+	  <ProjectReference Include="..\..\Common\Winterhaven.Common\Winterhaven.Common.csproj" />
 	  <ProjectReference Include="..\Winterhaven.API.Infrastructure\Winterhaven.API.Infrastructure.csproj" />
 	</ItemGroup>
 </Project>

--- a/src/Common/Winterhaven.Common/BuildInformation.cs
+++ b/src/Common/Winterhaven.Common/BuildInformation.cs
@@ -1,0 +1,30 @@
+﻿using System.Reflection;
+
+namespace Winterhaven.Common;
+
+/// <summary>
+///   Provides build information about Winterhaven.
+/// </summary>
+public static class BuildInformation
+{
+    /// <summary>
+    ///   Gets the version of Winterhaven from the assembly's informational version.
+    /// </summary>
+    /// <value>
+    ///   The version of Winterhaven, or "Unknown" if the informational version is not found.
+    /// </value>
+    public static string Version
+    {
+        get
+        {
+            var assembly = Assembly.GetExecutingAssembly();
+            var attribute = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
+
+            string version = attribute?.InformationalVersion ?? "Unknown";
+
+            //// The informational version may include a +gitsha suffix added by the SDK during build.
+            //// We want to strip this for display purposes (instead of "1.0.0+abc123", we want "1.0.0").
+            return version.Split('+')[0];
+        }
+    }
+}

--- a/src/Common/Winterhaven.Common/Winterhaven.Common.csproj
+++ b/src/Common/Winterhaven.Common/Winterhaven.Common.csproj
@@ -1,0 +1,1 @@
+﻿<Project Sdk="Microsoft.NET.Sdk" />

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,4 +1,4 @@
-<Project>
+﻿<Project>
 	<PropertyGroup>
 		<TargetFramework>net9.0</TargetFramework>
 		<Nullable>enable</Nullable>
@@ -18,9 +18,6 @@
 		<Product>Winterhaven Server</Product>
 		<Copyright>© 2026 Software Antics</Copyright>
 		<Trademark>Software Antics™</Trademark>
-		<Version>0.3.0</Version>
-		<AssemblyVersion>0.3.0.0</AssemblyVersion>
-		<FileVersion>0.3.0.0</FileVersion>
 		<AssemblyConfiguration Condition="'$(Configuration)' == 'Debug'">Debug</AssemblyConfiguration>
 		<AssemblyConfiguration Condition="'$(Configuration)' != 'Debug'">Release</AssemblyConfiguration>
 	</PropertyGroup>

--- a/src/Gateway/Dockerfile
+++ b/src/Gateway/Dockerfile
@@ -3,6 +3,10 @@ FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine AS build
 
 WORKDIR /app
 
+# TODO: Remove this, hack fix for this issue: https://github.com/reactiveui/refit/issues/2114
+# Stops NuGet from going online to check revocation status
+ENV NUGET_CERT_REVOCATION_MODE=offline
+
 # Copy shared properties first
 COPY Directory.Build.props .
 COPY Directory.Packages.props .

--- a/src/Gateway/Dockerfile
+++ b/src/Gateway/Dockerfile
@@ -26,6 +26,9 @@ COPY Gateway/Winterhaven.Gateway.Tests/Winterhaven.Gateway.Tests.csproj \
 COPY Gateway/Winterhaven.Gateway.Integrations/Winterhaven.Gateway.Integrations.csproj \
     Gateway/Winterhaven.Gateway.Integrations/
 
+COPY Common/Winterhaven.Common/Winterhaven.Common.csproj \
+    Common/Winterhaven.Common/
+
 COPY Common/Winterhaven.Common.DTOs/Winterhaven.Common.DTOs.csproj \
     Common/Winterhaven.Common.DTOs/
 

--- a/src/Gateway/Winterhaven.Gateway.Infrastructure/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Gateway/Winterhaven.Gateway.Infrastructure/Extensions/ServiceCollectionExtensions.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Reflection;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Refit;
+using Winterhaven.Common;
 using Winterhaven.Common.Extensions;
 using Winterhaven.Gateway.Core.Application.Clients.Users;
 using Winterhaven.Gateway.Core.Application.Services.Users;
@@ -66,13 +66,9 @@ public static class ServiceCollectionExtensions
         .ConfigureHttpClient((provider, client) =>
         {
             var settings = provider.GetRequiredService<IOptions<ClientOptions>>();
-            string version = Assembly
-                .GetExecutingAssembly()
-                .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
-                ?.InformationalVersion ?? "unknown";
 
             client.BaseAddress = new Uri($"{settings.Value.BaseUrl}/{route}");
-            client.DefaultRequestHeaders.UserAgent.ParseAdd($"Winterhaven Gateway/{version}");
+            client.DefaultRequestHeaders.UserAgent.ParseAdd($"Winterhaven Gateway/{BuildInformation.Version}");
         })
         .AddHttpMessageHandler<AccessTokenHandler>();
 

--- a/src/Gateway/Winterhaven.Gateway.Infrastructure/Winterhaven.Gateway.Infrastructure.csproj
+++ b/src/Gateway/Winterhaven.Gateway.Infrastructure/Winterhaven.Gateway.Infrastructure.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
     <ProjectReference Include="..\..\Common\Winterhaven.Common.Extensions\Winterhaven.Common.Extensions.csproj" />
+    <ProjectReference Include="..\..\Common\Winterhaven.Common\Winterhaven.Common.csproj" />
     <ProjectReference Include="..\Winterhaven.Gateway.Core.Application\Winterhaven.Gateway.Core.Application.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Server.slnx
+++ b/src/Server.slnx
@@ -33,6 +33,12 @@
     <Project Path="Common/Winterhaven.Common.Extensions/Winterhaven.Common.Extensions.csproj" Id="20cb5f40-08c9-424c-80aa-d6974ce4b194">
       <Platform Project="x64" />
     </Project>
+    <Project Path="Common/Winterhaven.Common/Winterhaven.Common.csproj" Id="eb80781c-be20-45b9-a6a6-709cb22890fc">
+      <Platform Project="x64" />
+    </Project>
+    <Project Path="Winterhaven.Common.Tests/Winterhaven.Common.Tests.csproj" Id="395b7b17-bda7-4023-bb67-a8027577d107">
+      <Platform Project="x64" />
+    </Project>
   </Folder>
   <Folder Name="/Gateway/" />
   <Folder Name="/Gateway/Core/">

--- a/src/Winterhaven.Common.Tests/BuildInformationTests.cs
+++ b/src/Winterhaven.Common.Tests/BuildInformationTests.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using NUnit.Framework;
+
+namespace Winterhaven.Common.Tests;
+
+[TestFixture]
+internal sealed class BuildInformationTests
+{
+    [Test]
+    public void VersionShouldReturnValidSemVer()
+    {
+        string version = BuildInformation.Version;
+        Assert.DoesNotThrow(() => Version.Parse(version));
+    }
+}

--- a/src/Winterhaven.Common.Tests/Winterhaven.Common.Tests.csproj
+++ b/src/Winterhaven.Common.Tests/Winterhaven.Common.Tests.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <Nullable>disable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit.Analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="NUnit3TestAdapter" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Common\Winterhaven.Common\Winterhaven.Common.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
- Fixes #174 

Refit needs to resign their packages, see reactiveui/refit#2114. TODO comments have been left temporarily until this is resolved to remove `NUGET_CERT_REVOCATION_MODE` from the build pipeline (Dockerfiles, workflows, etc).