### PR TITLE
✨ NATS Infrastructure Foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - [#95] - Gateway Refresh Token Flow (_by [@mathew-odwyer]_).
 - [#103] - Player Sessions via NATS (_by [@mathew-odwyer]_).
   - [#105] - Event Contracts and Application Interfaces (_by [@mathew-odwyer]_).
+  - [#104] - NATS Infrastructure Foundation (_by [@mathew-odwyer]_).
+  - [#107] - Room Service Event Consumers and Publising (_by [@mathew-odwyer]_).
 
 ### Fixed
 
@@ -83,6 +85,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [v0.2.0]: https://github.com/mathew-odwyer/Server/releases/tag/v0.2.0
 [v0.1.0]: https://github.com/mathew-odwyer/Server/releases/tag/v0.0.1
 
+[#107]: https://github.com/mathew-odwyer/Server/issues/107
+[#104]: https://github.com/mathew-odwyer/Server/issues/104
 [#103]: https://github.com/mathew-odwyer/Server/issues/103
 [#105]: https://github.com/mathew-odwyer/Server/issues/105
 [#111]: https://github.com/mathew-odwyer/Server/issues/111

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#103] - Player Sessions via NATS (_by [@mathew-odwyer]_).
   - [#105] - Event Contracts and Application Interfaces (_by [@mathew-odwyer]_).
   - [#104] - NATS Infrastructure Foundation (_by [@mathew-odwyer]_).
-  - [#107] - Room Service Event Consumers and Publising (_by [@mathew-odwyer]_).
 
 ### Fixed
 
@@ -85,7 +84,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [v0.2.0]: https://github.com/mathew-odwyer/Server/releases/tag/v0.2.0
 [v0.1.0]: https://github.com/mathew-odwyer/Server/releases/tag/v0.0.1
 
-[#107]: https://github.com/mathew-odwyer/Server/issues/107
 [#104]: https://github.com/mathew-odwyer/Server/issues/104
 [#103]: https://github.com/mathew-odwyer/Server/issues/103
 [#105]: https://github.com/mathew-odwyer/Server/issues/105

--- a/src/API/Dockerfile
+++ b/src/API/Dockerfile
@@ -24,9 +24,6 @@ COPY API/Winterhaven.API.Infrastructure/Winterhaven.API.Infrastructure.csproj \
 COPY API/Winterhaven.API.Presentation/Winterhaven.API.Presentation.csproj \
     API/Winterhaven.API.Presentation/
 
-COPY API/Winterhaven.API.Tests/Winterhaven.API.Tests.csproj \
-    API/Winterhaven.API.Tests/
-
 COPY Common/Winterhaven.Common/Winterhaven.Common.csproj \
     Common/Winterhaven.Common/
 
@@ -50,7 +47,6 @@ COPY API/ API/
 COPY Common/ Common/
 COPY Brokering/ Brokering/
 
-RUN dotnet test API/Winterhaven.API.Tests/Winterhaven.API.Tests.csproj -c Release --no-restore
 RUN dotnet publish API/Winterhaven.API.Presentation/Winterhaven.API.Presentation.csproj -c Release -o /out
 
 # Runtime Stage

--- a/src/Brokering/Winterhaven.Brokering.NATS.Tests/NatsMessageBusTests.cs
+++ b/src/Brokering/Winterhaven.Brokering.NATS.Tests/NatsMessageBusTests.cs
@@ -1,0 +1,330 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using NATS.Client.Core;
+using NSubstitute;
+using NUnit.Framework;
+using Winterhaven.Brokering.Events.Users;
+
+namespace Winterhaven.Brokering.NATS.Tests;
+
+[TestFixture]
+internal sealed class NatsMessageBusTests
+{
+    private INatsConnection connection;
+
+    private ILogger<NatsMessageBus> logger;
+
+    private NatsMessageBus messageBus;
+
+    private CancellationToken capturedToken;
+
+    [SetUp]
+    public void SetUp()
+    {
+        logger = Substitute.For<ILogger<NatsMessageBus>>();
+        connection = Substitute.For<INatsConnection>();
+        messageBus = new NatsMessageBus(logger, connection);
+        capturedToken = default;
+    }
+
+    [TearDown]
+    public async Task TearDown() =>
+        await connection.DisposeAsync().ConfigureAwait(false);
+
+    [Test]
+    public void ConstructorShouldThrowArgumentNullExceptionWhenConnectionIsNull() =>
+        Assert.Throws<ArgumentNullException>(() => new NatsMessageBus(logger, null));
+
+    [Test]
+    public void ConstructorShouldThrowArgumentNullExceptionWhenLoggerIsNull() =>
+        Assert.Throws<ArgumentNullException>(() => new NatsMessageBus(null, connection));
+
+    [Test]
+    public async Task PublishAsyncShouldInvokeNatsConnectionPublishAsyncOnceWhenInvoked()
+    {
+        // Arrange
+        const string username = "test-user";
+        const string accessToken = "access-token";
+
+        var notification = new UserLoggedInEvent(
+            Username: username,
+            AccessToken: accessToken);
+
+        var cancellationToken = new CancellationToken();
+
+        // Act
+        await messageBus.PublishAsync(notification, cancellationToken).ConfigureAwait(false);
+
+        // Assert
+        await connection.Received(1).PublishAsync(
+            subject: Arg.Is(nameof(UserLoggedInEvent)),
+            data: Arg.Is<UserLoggedInEvent>(x =>
+                x.Username == username &&
+                x.AccessToken == accessToken),
+            cancellationToken: Arg.Is(cancellationToken))
+            .ConfigureAwait(false);
+    }
+
+    [Test]
+    public void PublishAsyncShouldThrowArgumentNullExceptionWhenEventIsNull() =>
+        Assert.ThrowsAsync<ArgumentNullException>(() =>
+            messageBus.PublishAsync<UserLoggedInEvent>(null));
+
+    [Test]
+    public void SubscribeAsyncShouldThrowArgumentNullExceptionWhenConsumerIsNull() =>
+        Assert.ThrowsAsync<ArgumentNullException>(() =>
+            messageBus.SubscribeAsync<UserLoggedInEvent>(null));
+
+    [Test]
+    public async Task SubscribeAsyncShouldSubscribeToSubjectNamedAfterMessageType()
+    {
+        // Arrange
+        var channel = SetUpSubscribeCore<UserLoggedInEvent>();
+        channel.Writer.Complete();
+
+        // Act
+        await messageBus.SubscribeAsync<UserLoggedInEvent>(
+            (_, _) => Task.CompletedTask)
+            .ConfigureAwait(false);
+
+        // Assert
+        await connection.Received(1)
+            .SubscribeCoreAsync<UserLoggedInEvent>(
+                subject: Arg.Is(nameof(UserLoggedInEvent)),
+                cancellationToken: Arg.Any<CancellationToken>())
+            .ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task SubscribeAsyncShouldPassLinkedTokenToSubscribeCoreAsync()
+    {
+        // Arrange
+        var channel = SetUpSubscribeCore<UserLoggedInEvent>();
+        channel.Writer.Complete();
+
+        using var callerCts = new CancellationTokenSource();
+
+        // Act
+        await messageBus.SubscribeAsync<UserLoggedInEvent>(
+            (_, _) => Task.CompletedTask,
+            callerCts.Token)
+            .ConfigureAwait(false);
+
+        // Assert
+        Assert.That(capturedToken, Is.Not.EqualTo(callerCts.Token));
+    }
+
+    [Test]
+    public async Task SubscribeAsyncShouldCancelSubscribeCoreAsyncTokenWhenCallerTokenIsCancelled()
+    {
+        // Arrange
+        var channel = SetUpSubscribeCore<UserLoggedInEvent>();
+        channel.Writer.Complete();
+
+        using var callerCts = new CancellationTokenSource();
+
+        // Act
+        await messageBus.SubscribeAsync<UserLoggedInEvent>(
+            (_, _) => Task.CompletedTask,
+            callerCts.Token)
+            .ConfigureAwait(false);
+
+        Assert.That(capturedToken.IsCancellationRequested, Is.False,
+            "Token should not be cancelled before caller cancels");
+
+        await callerCts.CancelAsync().ConfigureAwait(false);
+
+        // Assert
+        Assert.That(capturedToken.IsCancellationRequested, Is.True,
+            "Linked token must be cancelled when the caller's token is cancelled");
+    }
+
+    [Test]
+    public async Task SubscribeAsyncShouldCancelSubscribeCoreAsyncTokenWhenSubscriptionIsDisposed()
+    {
+        // Arrange
+        SetUpSubscribeCore<UserLoggedInEvent>();
+
+        // Act
+        var subscription = await messageBus.SubscribeAsync<UserLoggedInEvent>(
+            (_, _) => Task.CompletedTask,
+            CancellationToken.None)
+            .ConfigureAwait(false);
+
+        Assert.That(capturedToken.IsCancellationRequested, Is.False,
+            "Token should not be cancelled before disposal");
+
+        await subscription.DisposeAsync().ConfigureAwait(false);
+
+        // Assert
+        Assert.That(capturedToken.IsCancellationRequested, Is.True,
+            "Linked token must be cancelled when the subscription is disposed");
+    }
+
+    [Test]
+    public async Task SubscribeAsyncShouldInvokeConsumerWhenMessageIsReceived()
+    {
+        // Arrange
+        var channel = SetUpSubscribeCore<UserLoggedInEvent>();
+
+        var received = new List<UserLoggedInEvent>();
+        var consumerInvoked = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        Task consumer(UserLoggedInEvent data, CancellationToken _ = default)
+        {
+            received.Add(data);
+            consumerInvoked.TrySetResult();
+            return Task.CompletedTask;
+        }
+
+        var expected = new UserLoggedInEvent(Username: "test-user", AccessToken: "token");
+
+        // Act
+        await messageBus.SubscribeAsync<UserLoggedInEvent>(consumer).ConfigureAwait(false);
+
+        await channel.Writer.WriteAsync(new NatsMsg<UserLoggedInEvent> { Data = expected })
+            .ConfigureAwait(false);
+
+        await consumerInvoked.Task.WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+        channel.Writer.Complete();
+
+        // Assert
+        Assert.That(received, Has.Count.EqualTo(1));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(received[0].Username, Is.EqualTo(expected.Username));
+            Assert.That(received[0].AccessToken, Is.EqualTo(expected.AccessToken));
+        }
+    }
+
+    [Test]
+    public async Task SubscribeAsyncShouldNotInvokeConsumerWhenMessageDataIsNull()
+    {
+        // Arrange
+        var channel = SetUpSubscribeCore<UserLoggedInEvent>();
+
+        int callCount = 0;
+        var sentinelReceived = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var sentinel = new UserLoggedInEvent(Username: "sentinel", AccessToken: "sentinel");
+
+        Task consumer(UserLoggedInEvent data, CancellationToken _ = default)
+        {
+            callCount++;
+            if (data == sentinel) sentinelReceived.TrySetResult();
+            return Task.CompletedTask;
+        }
+
+        // Act
+        await messageBus.SubscribeAsync<UserLoggedInEvent>(consumer).ConfigureAwait(false);
+
+        await channel.Writer.WriteAsync(new NatsMsg<UserLoggedInEvent> { Data = null })
+            .ConfigureAwait(false);
+        await channel.Writer.WriteAsync(new NatsMsg<UserLoggedInEvent> { Data = sentinel })
+            .ConfigureAwait(false);
+
+        await sentinelReceived.Task.WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+        channel.Writer.Complete();
+
+        // Assert
+        Assert.That(callCount, Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task SubscribeAsyncShouldLogErrorAndContinueWhenConsumerThrowsNonCancellationException()
+    {
+        // Arrange
+        var channel = SetUpSubscribeCore<UserLoggedInEvent>();
+
+        int callCount = 0;
+        var secondMessageReceived = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var message = new NatsMsg<UserLoggedInEvent>
+        {
+            Data = new UserLoggedInEvent(Username: "test-user", AccessToken: "token")
+        };
+
+        Task consumer(UserLoggedInEvent _, CancellationToken ct = default)
+        {
+            callCount++;
+            if (callCount == 1) throw new InvalidOperationException("boom");
+            secondMessageReceived.TrySetResult();
+            return Task.CompletedTask;
+        }
+
+        // Act
+        await messageBus.SubscribeAsync<UserLoggedInEvent>(consumer).ConfigureAwait(false);
+
+        await channel.Writer.WriteAsync(message).ConfigureAwait(false);
+        await channel.Writer.WriteAsync(message).ConfigureAwait(false);
+
+        // Assert
+        await secondMessageReceived.Task.WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+        channel.Writer.Complete();
+
+        logger.Received(1).Log(
+            LogLevel.Error,
+            Arg.Any<EventId>(),
+            Arg.Any<object>(),
+            Arg.Is<Exception>(ex => ex is InvalidOperationException),
+            Arg.Any<Func<object, Exception, string>>());
+    }
+
+    [Test]
+    public async Task SubscribeAsyncShouldExitLoopWhenConsumerThrowsOperationCanceledException()
+    {
+        // Arrange
+        var channel = SetUpSubscribeCore<UserLoggedInEvent>();
+
+        var consumerCalled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        Task consumer(UserLoggedInEvent _, CancellationToken ct = default)
+        {
+            consumerCalled.TrySetResult();
+            throw new OperationCanceledException(ct);
+        }
+
+        // Act
+        var subscription = await messageBus.SubscribeAsync<UserLoggedInEvent>(consumer)
+            .ConfigureAwait(false);
+
+        await channel.Writer.WriteAsync(new NatsMsg<UserLoggedInEvent>
+        {
+            Data = new UserLoggedInEvent(Username: "test-user", AccessToken: "token")
+        }).ConfigureAwait(false);
+
+        await consumerCalled.Task.WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+
+        // DisposeAsync must complete cleanly — the loop already exited via OCE
+        await subscription.DisposeAsync().ConfigureAwait(false);
+
+        // Assert — OCE must not be treated as a general error
+        logger.DidNotReceive().Log(
+            LogLevel.Error,
+            Arg.Any<EventId>(),
+            Arg.Any<object>(),
+            Arg.Any<Exception>(),
+            Arg.Any<Func<object, Exception, string>>());
+    }
+
+    private Channel<NatsMsg<TData>> SetUpSubscribeCore<TData>()
+        where TData : class
+    {
+        var channel = Channel.CreateUnbounded<NatsMsg<TData>>();
+        var fakeSubscription = Substitute.For<INatsSub<TData>>();
+        fakeSubscription.Msgs.Returns(channel.Reader);
+
+#pragma warning disable CA2012
+        connection
+            .SubscribeCoreAsync<TData>(
+                Arg.Any<string>(),
+                cancellationToken: Arg.Do<CancellationToken>(t => capturedToken = t))
+            .Returns(_ => ValueTask.FromResult(fakeSubscription));
+#pragma warning restore CA2012
+
+        return channel;
+    }
+}

--- a/src/Brokering/Winterhaven.Brokering.NATS.Tests/NatsMessageBusTests.cs
+++ b/src/Brokering/Winterhaven.Brokering.NATS.Tests/NatsMessageBusTests.cs
@@ -174,7 +174,7 @@ internal sealed class NatsMessageBusTests
         var received = new List<UserLoggedInEvent>();
         var consumerInvoked = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        Task consumer(UserLoggedInEvent data, CancellationToken _ = default)
+        Task Consumer(UserLoggedInEvent data, CancellationToken _ = default)
         {
             received.Add(data);
             consumerInvoked.TrySetResult();
@@ -184,7 +184,7 @@ internal sealed class NatsMessageBusTests
         var expected = new UserLoggedInEvent(Username: "test-user", AccessToken: "token");
 
         // Act
-        await messageBus.SubscribeAsync<UserLoggedInEvent>(consumer).ConfigureAwait(false);
+        await messageBus.SubscribeAsync<UserLoggedInEvent>(Consumer).ConfigureAwait(false);
 
         await channel.Writer.WriteAsync(new NatsMsg<UserLoggedInEvent> { Data = expected })
             .ConfigureAwait(false);
@@ -211,7 +211,7 @@ internal sealed class NatsMessageBusTests
         var sentinelReceived = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var sentinel = new UserLoggedInEvent(Username: "sentinel", AccessToken: "sentinel");
 
-        Task consumer(UserLoggedInEvent data, CancellationToken _ = default)
+        Task Consumer(UserLoggedInEvent data, CancellationToken _ = default)
         {
             callCount++;
             if (data == sentinel) sentinelReceived.TrySetResult();
@@ -219,7 +219,7 @@ internal sealed class NatsMessageBusTests
         }
 
         // Act
-        await messageBus.SubscribeAsync<UserLoggedInEvent>(consumer).ConfigureAwait(false);
+        await messageBus.SubscribeAsync<UserLoggedInEvent>(Consumer).ConfigureAwait(false);
 
         await channel.Writer.WriteAsync(new NatsMsg<UserLoggedInEvent> { Data = null })
             .ConfigureAwait(false);
@@ -247,7 +247,7 @@ internal sealed class NatsMessageBusTests
             Data = new UserLoggedInEvent(Username: "test-user", AccessToken: "token")
         };
 
-        Task consumer(UserLoggedInEvent _, CancellationToken ct = default)
+        Task Consumer(UserLoggedInEvent _)
         {
             callCount++;
             if (callCount == 1) throw new InvalidOperationException("boom");
@@ -256,7 +256,7 @@ internal sealed class NatsMessageBusTests
         }
 
         // Act
-        await messageBus.SubscribeAsync<UserLoggedInEvent>(consumer).ConfigureAwait(false);
+        await messageBus.SubscribeAsync<UserLoggedInEvent>((_, _) => Consumer(null)).ConfigureAwait(false);
 
         await channel.Writer.WriteAsync(message).ConfigureAwait(false);
         await channel.Writer.WriteAsync(message).ConfigureAwait(false);
@@ -281,14 +281,14 @@ internal sealed class NatsMessageBusTests
 
         var consumerCalled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        Task consumer(UserLoggedInEvent _, CancellationToken ct = default)
+        Task Consumer(UserLoggedInEvent _, CancellationToken ct = default)
         {
             consumerCalled.TrySetResult();
             throw new OperationCanceledException(ct);
         }
 
         // Act
-        var subscription = await messageBus.SubscribeAsync<UserLoggedInEvent>(consumer)
+        var subscription = await messageBus.SubscribeAsync<UserLoggedInEvent>(Consumer)
             .ConfigureAwait(false);
 
         await channel.Writer.WriteAsync(new NatsMsg<UserLoggedInEvent>

--- a/src/Brokering/Winterhaven.Brokering.NATS.Tests/Winterhaven.Brokering.NATS.Tests.csproj
+++ b/src/Brokering/Winterhaven.Brokering.NATS.Tests/Winterhaven.Brokering.NATS.Tests.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <Nullable>disable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit.Analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="NUnit3TestAdapter" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Winterhaven.Brokering.NATS\Winterhaven.Brokering.NATS.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Brokering/Winterhaven.Brokering.NATS/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Brokering/Winterhaven.Brokering.NATS/Extensions/ServiceCollectionExtensions.cs
@@ -1,5 +1,8 @@
 ﻿using System;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using NATS.Client.Hosting;
+using NATS.Client.Serializers.Json;
 
 namespace Winterhaven.Brokering.NATS.Extensions;
 
@@ -14,12 +17,23 @@ public static class ServiceCollectionExtensions
     /// <param name="services">
     ///   The <see cref="IServiceCollection"/> to which the brokering services will be added.
     /// </param>
+    /// <param name="configuration">
+    ///   The <see cref="IConfiguration"/> instance that provides access to the application's configuration settings.
+    /// </param>
     /// <returns>
     ///   The same <see cref="IServiceCollection"/> instance that was passed in, allowing for method chaining when configuring services.
     /// </returns>
-    public static IServiceCollection AddBrokeringServices(this IServiceCollection services)
+    public static IServiceCollection AddBrokeringServices(this IServiceCollection services, IConfiguration configuration)
     {
         ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        services.AddNats(1, x => x with
+        {
+            Name = "winterhaven-nats",
+            Url = configuration["NATS_URL"] ?? "ws://nats:9222",
+            SerializerRegistry = NatsJsonSerializerRegistry.Default,
+        });
 
         services.AddSingleton<IMessageBus, NatsMessageBus>();
 

--- a/src/Brokering/Winterhaven.Brokering.NATS/NatsMessageBus.cs
+++ b/src/Brokering/Winterhaven.Brokering.NATS/NatsMessageBus.cs
@@ -1,12 +1,124 @@
-﻿using System.Threading;
+﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using NATS.Client.Core;
 
 namespace Winterhaven.Brokering.NATS;
 
-// TODO: Update UserRpcTargetIntegrationTests to check that the NATS message bus is actually working and delivering messages to subscribers, instead of just being a no-op implementation. This will help ensure that the NATS integration is functioning correctly and that messages are being published and consumed as expected.
 internal sealed class NatsMessageBus : IMessageBus
 {
-    public Task PublishAsync<TData>(TData data, CancellationToken cancellationToken = default) where TData : class => Task.CompletedTask;
+    private readonly INatsConnection connection;
 
-    public Task SubscribeAsync<TData>(MessageConsumer<TData> consumer, CancellationToken cancellationToken = default) where TData : class => Task.CompletedTask;
+    private readonly ILogger<NatsMessageBus> logger;
+
+    public NatsMessageBus(ILogger<NatsMessageBus> logger, INatsConnection connection)
+    {
+        this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        this.connection = connection ?? throw new ArgumentNullException(nameof(connection));
+    }
+
+    public async Task PublishAsync<TData>(TData data, CancellationToken cancellationToken = default)
+        where TData : class
+    {
+        ArgumentNullException.ThrowIfNull(data);
+
+        string subject = typeof(TData).Name;
+
+        logger.LogTrace("Publishing message of type '{MessageType}' to subject '{Subject}'", typeof(TData).FullName, subject);
+
+        await connection.PublishAsync(
+            subject: subject,
+            data: data,
+            cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public async Task<IAsyncDisposable> SubscribeAsync<TData>(
+        MessageConsumer<TData> consumer,
+        CancellationToken cancellationToken = default)
+        where TData : class
+    {
+        ArgumentNullException.ThrowIfNull(consumer);
+
+        string subject = typeof(TData).Name;
+
+        logger.LogTrace("Subscribing to '{MessageType}' on '{Subject}'", typeof(TData).FullName, subject);
+
+        //// Link to the caller's token so either the caller cancelling or DisposeAsync()
+        //// can stop the loop. Without this we'd have no owned handle to cancel on disposal.
+        var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+
+        var subscription = await connection
+            .SubscribeCoreAsync<TData>(subject, cancellationToken: cts.Token)
+            .ConfigureAwait(false);
+
+        var loopTask = Task.Run(async () =>
+        {
+            // Exceptions are caught per-message so a single bad message doesn't kill the entire subscription. OperationCanceledException is intentionally let through so the loop exits cleanly when the token is cancelled.
+            await foreach (var msg in subscription.Msgs.ReadAllAsync(cts.Token).ConfigureAwait(false))
+            {
+                if (msg.Data is null) continue;
+
+                try
+                {
+                    await consumer(msg.Data, cts.Token).ConfigureAwait(false);
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    logger.LogError(ex, "Unhandled exception in consumer for subject '{Subject}'", subject);
+                }
+            }
+        }, cts.Token);
+
+        return new NatsSubscription<TData>(subscription, cts, loopTask, logger);
+    }
+
+    private class NatsSubscription<TData> : IAsyncDisposable
+        where TData : class
+    {
+        private readonly CancellationTokenSource cts;
+
+        private readonly ILogger<NatsMessageBus> logger;
+
+        private readonly Task loopTask;
+
+        private readonly INatsSub<TData> subscription;
+
+        public NatsSubscription(
+            INatsSub<TData> subscription,
+            CancellationTokenSource cts,
+            Task loopTask,
+            ILogger<NatsMessageBus> logger)
+        {
+            this.subscription = subscription;
+            this.cts = cts;
+            this.loopTask = loopTask;
+            this.logger = logger;
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            //// Cancel first, then wait for the loop to fully exit before disposing the NATS subscription.
+            //// This avoids a race where the loop tries to read from a disposed channel.
+            await cts.CancelAsync().ConfigureAwait(false);
+
+            try
+            {
+                await loopTask.ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                // Expected if the token is cancelled.
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Exception during subscription loop teardown");
+                throw;
+            }
+
+            await subscription.DisposeAsync().ConfigureAwait(false);
+            cts.Dispose();
+        }
+    }
 }

--- a/src/Brokering/Winterhaven.Brokering.NATS/Winterhaven.Brokering.NATS.csproj
+++ b/src/Brokering/Winterhaven.Brokering.NATS/Winterhaven.Brokering.NATS.csproj
@@ -1,6 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="NATS.Net" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>Winterhaven.Brokering.NATS.Tests</_Parameter1>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>DynamicProxyGenAssembly2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7</_Parameter1>
+    </AssemblyAttribute>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Brokering/Winterhaven.Brokering/IMessageBus.cs
+++ b/src/Brokering/Winterhaven.Brokering/IMessageBus.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading;
+﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Winterhaven.Brokering;
@@ -12,7 +13,10 @@ namespace Winterhaven.Brokering;
 /// <param name="data">
 ///   The message data that the consumer will process.
 /// </param>
-public delegate Task MessageConsumer<TData>(TData data)
+/// <param name="cancellationToken">
+///   The cancellation token used to cancel the operation.
+/// </param>
+public delegate Task MessageConsumer<TData>(TData data, CancellationToken cancellationToken = default)
     where TData : class;
 
 /// <summary>
@@ -59,6 +63,8 @@ public interface IMessageBus
     /// <remarks>
     ///   The contract does not guarantee that the consumer will receive all messages of the specified type, as it is possible for some messages to be missed due to various reasons such as network issues or subscriber downtime. Therefore, it is the responsibility of the implementation to document the delivery guarantees and behavior of the message bus, including any potential limitations or scenarios where messages may not be delivered to subscribers.
     /// </remarks>
-    public Task SubscribeAsync<TData>(MessageConsumer<TData> consumer, CancellationToken cancellationToken = default)
+    public Task<IAsyncDisposable> SubscribeAsync<TData>(
+        MessageConsumer<TData> consumer,
+        CancellationToken cancellationToken = default)
         where TData : class;
 }

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -15,6 +15,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.DataProtection" Version="9.0.16" />
     <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.14.0" />
     <PackageVersion Include="Microsoft.IdentityModel.Tokens" Version="8.14.0" />
+    <PackageVersion Include="NATS.Net" Version="2.8.1" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.14.0" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="Refit" Version="10.1.6" />
@@ -33,6 +34,7 @@
     <PackageVersion Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.6.0" />
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="9.0.16" />
+    <PackageVersion Include="Testcontainers.Nats" Version="4.12.0" />
     <PackageVersion Include="WireMock.Net" Version="2.8.0" />
   </ItemGroup>
 </Project>

--- a/src/Gateway/Dockerfile
+++ b/src/Gateway/Dockerfile
@@ -24,12 +24,6 @@ COPY Gateway/Winterhaven.Gateway.Infrastructure/Winterhaven.Gateway.Infrastructu
 COPY Gateway/Winterhaven.Gateway.Presentation/Winterhaven.Gateway.Presentation.csproj \
     Gateway/Winterhaven.Gateway.Presentation/
 
-COPY Gateway/Winterhaven.Gateway.Tests/Winterhaven.Gateway.Tests.csproj \
-    Gateway/Winterhaven.Gateway.Tests/
-
-COPY Gateway/Winterhaven.Gateway.Integrations/Winterhaven.Gateway.Integrations.csproj \
-    Gateway/Winterhaven.Gateway.Integrations/
-
 COPY Common/Winterhaven.Common/Winterhaven.Common.csproj \
     Common/Winterhaven.Common/
 
@@ -53,8 +47,6 @@ COPY Gateway/ Gateway/
 COPY Common/ Common/
 COPY Brokering/ Brokering/
 
-RUN dotnet test Gateway/Winterhaven.Gateway.Tests/Winterhaven.Gateway.Tests.csproj -c Release --no-restore
-RUN dotnet test Gateway/Winterhaven.Gateway.Integrations/Winterhaven.Gateway.Integrations.csproj -c Release --no-restore
 RUN dotnet publish Gateway/Winterhaven.Gateway.Presentation/Winterhaven.Gateway.Presentation.csproj -c Release -o /out
 
 # Runtime Stage

--- a/src/Gateway/Winterhaven.Gateway.Integrations/Presentation/GatewayJsonRpcIntegrationTests.cs
+++ b/src/Gateway/Winterhaven.Gateway.Integrations/Presentation/GatewayJsonRpcIntegrationTests.cs
@@ -151,10 +151,4 @@ internal sealed class GatewayJsonRpcIntegrationTests : TestHostBase
             Assert.That(exception.Message, Is.EqualTo(expectedMessage));
         }
     }
-
-    [SetUp]
-    public async Task SetUp() => await SetUpTestHost().ConfigureAwait(false);
-
-    [TearDown]
-    public async Task TearDown() => await TearDownTestHost().ConfigureAwait(false);
 }

--- a/src/Gateway/Winterhaven.Gateway.Integrations/Presentation/Services/Sessions/WebSocketRpcSessionIntegrationTests.cs
+++ b/src/Gateway/Winterhaven.Gateway.Integrations/Presentation/Services/Sessions/WebSocketRpcSessionIntegrationTests.cs
@@ -111,10 +111,4 @@ internal sealed class WebSocketRpcSessionIntegrationTests : TestHostBase
         Assert.That(response, Does.Contain("\"id\":1"));
         Assert.That(response, Does.Contain("\"error\""));
     }
-
-    [SetUp]
-    public async Task Setup() => await SetUpTestHost();
-
-    [TearDown]
-    public async Task TearDown() => await TearDownTestHost();
 }

--- a/src/Gateway/Winterhaven.Gateway.Integrations/Presentation/Targets/Users/UserRpcTargetIntegrationTests.cs
+++ b/src/Gateway/Winterhaven.Gateway.Integrations/Presentation/Targets/Users/UserRpcTargetIntegrationTests.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using StreamJsonRpc;
+using Winterhaven.Brokering.Events.Users;
 using Winterhaven.Common.DTOs.Users;
 using Winterhaven.Gateway.Core.Domain.ValueObjects.Users;
 using Winterhaven.Gateway.Integrations.Services.Clients;
@@ -14,15 +16,60 @@ namespace Winterhaven.Gateway.Integrations.Presentation.Targets.Users;
 [TestFixture]
 internal sealed class UserRpcTargetIntegrationTests : TestHostBase
 {
-    [SetUp]
-    public async Task SetUp()
+    [Test]
+    public async Task DisconnectShouldPublishUserLoggedOutEventWhenUserIsLoggedIn()
     {
-        await SetUpTestHost();
-        UserSessionManager.InvalidateUserSession();
+        // Arrange
+        await using var connection = await CreateConnectionAsync(x =>
+            x.WithProxy<IUserClientProxy>());
+
+        var identifier = Guid.NewGuid();
+        const string username = "test-user";
+
+        Api
+            .Given(Request.Create().WithPath("/api/UserAccount/Logout").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(HttpStatusCode.NoContent));
+
+        UserSessionManager.EstablishUserSession(new UserSession(
+            UserAccountId: identifier,
+            Username: username,
+            AccessToken: CreateAccessToken(identifier, username),
+            ExpiresAt: DateTime.UtcNow.AddMinutes(15)));
+
+        var eventReceived = new TaskCompletionSource<bool>();
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(500));
+        cts.Token.Register(() => eventReceived.TrySetCanceled());
+
+        await using var subscription = await MessageBus.SubscribeAsync<UserLoggedOutEvent>((e, _) =>
+        {
+            // Signal that the event was received.
+            eventReceived.SetResult(true);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(e.Username, Is.EqualTo(username));
+            }
+
+            return Task.CompletedTask;
+        });
+
+        // Act
+        await connection.DisposeAsync();
+
+        try
+        {
+            // Wait for the event to be received, because of cts we are waiting 5 seconds for a response.
+            await eventReceived.Task;
+        }
+        catch (OperationCanceledException)
+        {
+            Assert.Fail("Event was not received within 5 seconds");
+        }
     }
 
-    [TearDown]
-    public async Task TearDown() => await TearDownTestHost();
+    [SetUp]
+    public void SetUp() => UserSessionManager.InvalidateUserSession();
 
     [Test]
     public async Task UserLoginRequestShouldLoginUserWhenCredentialsAreCorrect()
@@ -96,6 +143,62 @@ internal sealed class UserRpcTargetIntegrationTests : TestHostBase
     }
 
     [Test]
+    public async Task UserLoginShouldPublishUserLoggedInEventWhenCredentialsAreCorrect()
+    {
+        // Arrange
+        const string username = "testuser";
+        const string password = "password";
+
+        var apiResponse = new LoginUserResponseDto(
+            AccessToken: CreateAccessToken(Guid.NewGuid(), username),
+            RefreshToken: "refreshToken");
+
+        Api
+            .Given(Request.Create().WithPath("/api/UserAccount/Login").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(HttpStatusCode.OK).WithBodyAsJson(apiResponse));
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var eventReceived = new TaskCompletionSource<bool>();
+
+        // If the login is cancelled for whatever reason, cancel the event received.
+        cts.Token.Register(() => eventReceived.TrySetCanceled());
+
+        await using var subscription = await MessageBus.SubscribeAsync<UserLoggedInEvent>((e, _) =>
+        {
+            // Signal that the event was received.
+            eventReceived.SetResult(true);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(e.Username, Is.EqualTo(username));
+                Assert.That(e.AccessToken, Is.EqualTo(apiResponse.AccessToken));
+            }
+
+            return Task.CompletedTask;
+        });
+
+        await using var connection = await CreateConnectionAsync(
+           x => x.WithProxy<IUserClientProxy>());
+
+        var userProxy = connection.GetProxy<IUserClientProxy>();
+
+        // Act
+        await userProxy.LoginAsync(
+            username: username,
+            password: password, cts.Token);
+
+        try
+        {
+            // Wait for the event to be received, because of cts we are waiting 5 seconds for a response.
+            await eventReceived.Task;
+        }
+        catch (OperationCanceledException)
+        {
+            Assert.Fail("Event was not received within 5 seconds");
+        }
+    }
+
+    [Test]
     public async Task UserRefreshShouldReturnAuthorizationErrorWhenUserIsNotLoggedIn()
     {
         var apiResponse = new
@@ -103,7 +206,6 @@ internal sealed class UserRpcTargetIntegrationTests : TestHostBase
             Type = "https://tools.ietf.org/html/rfc7235#section-3.1",
             Title = "Unauthorized",
             Status = 401,
-            TraceId = Guid.NewGuid().ToString(),
         };
 
         Api

--- a/src/Gateway/Winterhaven.Gateway.Integrations/TestHostBase.cs
+++ b/src/Gateway/Winterhaven.Gateway.Integrations/TestHostBase.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
+using System.IO;
 using System.Security.Claims;
 using System.Text;
 using System.Threading;
@@ -10,6 +12,9 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.IdentityModel.Tokens;
+using NUnit.Framework;
+using Testcontainers.Nats;
+using Winterhaven.Brokering;
 using Winterhaven.Gateway.Core.Application.Services.Users;
 using Winterhaven.Gateway.Infrastructure.Options.Client;
 using Winterhaven.Gateway.Infrastructure.Services.Users;
@@ -24,11 +29,78 @@ namespace Winterhaven.Gateway.Integrations;
 
 internal abstract class TestHostBase
 {
+    private NatsContainer natsContainer;
+
     protected WireMockServer Api { get; private set; }
 
     protected IHost Host { get; private set; }
 
+    protected IMessageBus MessageBus => Host.Services.GetRequiredService<IMessageBus>();
+
     protected MockUserSessionManager UserSessionManager { get; } = new();
+
+    [OneTimeSetUp]
+    public virtual async Task OneTimeSetUp()
+    {
+        natsContainer = new NatsBuilder("nats:latest")
+            .WithPortBinding(9222, true)
+            .WithResourceMapping(
+                Encoding.UTF8.GetBytes(await File.ReadAllTextAsync("nats-test.conf")),
+                "/etc/nats/nats.conf")
+            .WithCommand("-c", "/etc/nats/nats.conf")
+            .Build();
+
+        await natsContainer.StartAsync();
+
+        Api = WireMockServer.Start();
+
+        var builder = new HostBuilder();
+
+        builder.ConfigureWebHost(x =>
+        {
+            x.UseStartup<Startup>();
+            x.UseTestServer();
+            x.ConfigureAppConfiguration(config =>
+            {
+                config.AddJsonFile("appsettings.Tests.json", optional: false);
+
+                //// Override environment variables via in-memory config, this takes priority.
+                //// Prefer this approach over Environment.SetEnvironmentVariable because some
+                //// services require variables to be set during DI registration.
+                config.AddInMemoryCollection(new Dictionary<string, string>
+                {
+                    ["NATS_URL"] = $"ws://localhost:{natsContainer.GetMappedPublicPort(9222)}"
+                });
+            });
+            x.ConfigureTestServices(services =>
+            {
+                services.AddScoped<IRpcTarget, TestErrorRpcTarget>();
+                services.AddScoped<IRpcTarget, TestAuthRpcTarget>();
+
+                services.AddSingleton<IUserSessionContext>(UserSessionManager);
+                services.AddSingleton<IUserSessionManager>(UserSessionManager);
+
+                services.PostConfigure<ClientOptions>(x => x.BaseUrl = Api.Url);
+            });
+        });
+
+        Host = builder.Build();
+        await Host.StartAsync().ConfigureAwait(false);
+    }
+
+    [OneTimeTearDown]
+    public virtual async Task OneTimeTearDown()
+    {
+        await Host.StopAsync().ConfigureAwait(false);
+
+        Host.Dispose();
+
+        Api.Stop();
+        Api.Dispose();
+
+        await natsContainer.StopAsync();
+        await natsContainer.DisposeAsync();
+    }
 
     protected string CreateAccessToken(Guid identifier, string username)
     {
@@ -63,42 +135,5 @@ internal abstract class TestHostBase
         var webSocket = await client.ConnectAsync(new Uri(uri), cancellationToken).ConfigureAwait(false);
 
         return builder.Build(webSocket);
-    }
-
-    protected async Task SetUpTestHost()
-    {
-        Api = WireMockServer.Start();
-
-        var builder = new HostBuilder();
-
-        builder.ConfigureWebHost(x =>
-        {
-            x.UseStartup<Startup>();
-            x.UseTestServer();
-            x.ConfigureAppConfiguration(x => x.AddJsonFile("appsettings.Tests.json", optional: false));
-            x.ConfigureTestServices(services =>
-            {
-                services.AddScoped<IRpcTarget, TestErrorRpcTarget>();
-                services.AddScoped<IRpcTarget, TestAuthRpcTarget>();
-
-                services.AddSingleton<IUserSessionContext>(UserSessionManager);
-                services.AddSingleton<IUserSessionManager>(UserSessionManager);
-
-                services.PostConfigure<ClientOptions>(x => x.BaseUrl = Api.Url);
-            });
-        });
-
-        Host = builder.Build();
-        await Host.StartAsync().ConfigureAwait(false);
-    }
-
-    protected async Task TearDownTestHost()
-    {
-        await Host.StopAsync().ConfigureAwait(false);
-
-        Host.Dispose();
-
-        Api.Stop();
-        Api.Dispose();
     }
 }

--- a/src/Gateway/Winterhaven.Gateway.Integrations/Winterhaven.Gateway.Integrations.csproj
+++ b/src/Gateway/Winterhaven.Gateway.Integrations/Winterhaven.Gateway.Integrations.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="NUnit3TestAdapter">
       <TreatAsUsed>true</TreatAsUsed>
     </PackageReference>
+    <PackageReference Include="Testcontainers.Nats" />
     <PackageReference Include="WireMock.Net" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
@@ -31,5 +32,11 @@
     <ProjectReference Include="..\Winterhaven.Gateway.Core.Domain\Winterhaven.Gateway.Core.Domain.csproj" />
     <ProjectReference Include="..\Winterhaven.Gateway.Infrastructure\Winterhaven.Gateway.Infrastructure.csproj" />
     <ProjectReference Include="..\Winterhaven.Gateway.Presentation\Winterhaven.Gateway.Presentation.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="nats-test.conf">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 </Project>

--- a/src/Gateway/Winterhaven.Gateway.Integrations/nats-test.conf
+++ b/src/Gateway/Winterhaven.Gateway.Integrations/nats-test.conf
@@ -1,0 +1,15 @@
+﻿# Identity stuffs
+server_name: "nats-winterhaven"
+
+# Monitoring endpoint.
+http: 8222
+
+websocket {
+  port: 9222
+  no_tls: true
+}
+
+# Logging
+debug: true
+trace: true
+logtime: true

--- a/src/Gateway/Winterhaven.Gateway.Presentation/Startup.cs
+++ b/src/Gateway/Winterhaven.Gateway.Presentation/Startup.cs
@@ -75,9 +75,8 @@ internal sealed class Startup
         services.AddRpcSessionTarget<HealthRpcTarget>();
         services.AddRpcSessionTarget<UserRpcTarget>();
 
+        services.AddBrokeringServices(Configuration);
         services.AddGatewayInfrastructureServices(Configuration);
-
-        services.AddBrokeringServices();
 
         services.AddHttpContextAccessor();
     }

--- a/src/Server.slnx
+++ b/src/Server.slnx
@@ -27,6 +27,9 @@
     </Project>
   </Folder>
   <Folder Name="/Brokering/">
+    <Project Path="Brokering/Winterhaven.Brokering.NATS.Tests/Winterhaven.Brokering.NATS.Tests.csproj" Id="2b5bc6b6-099d-4946-a269-66adedfe0e9a">
+      <Platform Project="x64" />
+    </Project>
     <Project Path="Brokering/Winterhaven.Brokering.NATS/Winterhaven.Brokering.NATS.csproj" Id="12d8804c-2c64-4873-984b-4dc399755ae3">
       <Platform Project="x64" />
     </Project>


### PR DESCRIPTION
# Description

This PR introduces the NATS infrastructure foundation and a standard implementation of `IMessageBus` which can be used to subscribe to and publish events.

- Fixes #104 

## Dependencies

This PR introduces the following new dependencies:

- [NATS.Net](https://www.nuget.org/packages/NATS.Net)
- [TestContainers.NATS](https://www.nuget.org/packages/Testcontainers.Nats)

## Type of change

- [x] New feature (non-breaking change which adds functionality).

## How Has This Been Tested?

I have updated existing integration test to ensure that `UserLoggedInEvent` and `UserLoggedOutEvent` are both fired in `UserAccountService`. I also added unit tests to ensure that the `NatsMessageBus` is working as expected, covering most of the branches.

**Test Configuration**:
* Operating System: Windows 11 Home
* Hardware: Intel i7-10710U, 32GB RAM, Intel UHD Graphics
* Toolchain: VS Community 2022

## Proposed Design

I've made slight changes to the `IMessageBus` contract by ensuring that the `MessageConsumer` returns a `Task` as well as updated the `SubscribeAsync` function to return a `Task<IAsyncDisposable` which can be used to kill the subscription as well as ensure the linked token is disposed. The linked token has been added so that either the caller _or_ a call to `await subscription.DisposeAsync()` will stop the loop. Please note that I'm not 100% certain if the subscription will be unsubscribed via NATS, but nonetheless the messages will not be received be a dangling consumer.

## Checklist:

- [x] I have updated the CHANGELOG to reflect my changes
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have not used `ExcludeFromCodeCoverageAttribute` on a class with logic.
- [x] New and existing tests pass locally with my changes
- [x] My changes generate no new warnings
